### PR TITLE
Add console app scaffold with JSON params parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+**/bin/
+**/obj/

--- a/ExcelJobRunner.Tests/ExcelJobRunner.Tests.csproj
+++ b/ExcelJobRunner.Tests/ExcelJobRunner.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ExcelJobRunner\ExcelJobRunner.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ExcelJobRunner.Tests/GlobalUsings.cs
+++ b/ExcelJobRunner.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/ExcelJobRunner.Tests/ParamsParserTests.cs
+++ b/ExcelJobRunner.Tests/ParamsParserTests.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using ExcelJobRunner;
+using ExcelJobRunner.Models;
+using Xunit;
+
+namespace ExcelJobRunner.Tests;
+
+public class ParamsParserTests
+{
+    [Fact]
+    public void UpdateLinksParams_CanBeReadFromJson()
+    {
+        var json = """
+{
+  "inputFile": "file.xlsx",
+  "cells": [{ "address": "Sheet1!A1", "newValue": "test" }],
+  "outputFile": "out.xlsx"
+}
+""";
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, json);
+
+        var text = File.ReadAllText(path);
+        var result = ParamsParser.Parse("updateLinks", text);
+
+        var parsed = Assert.IsType<UpdateLinksParams>(result);
+        Assert.Equal("file.xlsx", parsed.InputFile);
+        Assert.Single(parsed.Cells!);
+        Assert.Equal("Sheet1!A1", parsed.Cells![0].Address);
+    }
+}

--- a/ExcelJobRunner/ExcelJobRunner.csproj
+++ b/ExcelJobRunner/ExcelJobRunner.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/ExcelJobRunner/JobResult.cs
+++ b/ExcelJobRunner/JobResult.cs
@@ -1,0 +1,3 @@
+namespace ExcelJobRunner;
+
+public record JobResult(string Status, string Message);

--- a/ExcelJobRunner/Models/CopyColumnsParams.cs
+++ b/ExcelJobRunner/Models/CopyColumnsParams.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace ExcelJobRunner.Models;
+
+public class CopyColumnsParams
+{
+    public string? InputFile { get; set; }
+    public List<ColumnCopy>? Columns { get; set; }
+    public string? OutputFile { get; set; }
+}
+
+public class ColumnCopy
+{
+    public string? From { get; set; }
+    public string? To { get; set; }
+}

--- a/ExcelJobRunner/Models/FindErrorsParams.cs
+++ b/ExcelJobRunner/Models/FindErrorsParams.cs
@@ -1,0 +1,7 @@
+namespace ExcelJobRunner.Models;
+
+public class FindErrorsParams
+{
+    public string? InputFile { get; set; }
+    public string? OutputFile { get; set; }
+}

--- a/ExcelJobRunner/Models/RecalculateParams.cs
+++ b/ExcelJobRunner/Models/RecalculateParams.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace ExcelJobRunner.Models;
+
+public class RecalculateParams
+{
+    public string? InputFile { get; set; }
+    public List<string>? Sheets { get; set; }
+    public string? OutputFile { get; set; }
+}

--- a/ExcelJobRunner/Models/UpdateLinksParams.cs
+++ b/ExcelJobRunner/Models/UpdateLinksParams.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace ExcelJobRunner.Models;
+
+public class UpdateLinksParams
+{
+    public string? InputFile { get; set; }
+    public List<CellUpdate>? Cells { get; set; }
+    public string? OutputFile { get; set; }
+}
+
+public class CellUpdate
+{
+    public string? Address { get; set; }
+    public string? NewValue { get; set; }
+}

--- a/ExcelJobRunner/ParamsParser.cs
+++ b/ExcelJobRunner/ParamsParser.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Text.Json;
+using ExcelJobRunner.Models;
+
+namespace ExcelJobRunner;
+
+public static class ParamsParser
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static object Parse(string action, string json)
+    {
+        return action switch
+        {
+            "updateLinks" => JsonSerializer.Deserialize<UpdateLinksParams>(json, Options)
+                               ?? throw new JsonException("Invalid updateLinks params"),
+            "copyColumns" => JsonSerializer.Deserialize<CopyColumnsParams>(json, Options)
+                               ?? throw new JsonException("Invalid copyColumns params"),
+            "recalculate" => JsonSerializer.Deserialize<RecalculateParams>(json, Options)
+                               ?? throw new JsonException("Invalid recalculate params"),
+            "findErrors" => JsonSerializer.Deserialize<FindErrorsParams>(json, Options)
+                               ?? throw new JsonException("Invalid findErrors params"),
+            _ => throw new ArgumentException($"Unknown action: {action}")
+        };
+    }
+}

--- a/ExcelJobRunner/Program.cs
+++ b/ExcelJobRunner/Program.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace ExcelJobRunner;
+
+public class Program
+{
+    private static readonly HashSet<string> AllowedActions = new(new[] { "updateLinks", "copyColumns", "recalculate", "findErrors" });
+
+    public static int Main(string[] args)
+    {
+        if (!TryParseArgs(args, out var action, out var paramsPath, out var resultPath, out var error))
+        {
+            WriteResult(resultPath, new JobResult("Fail", error ?? "Invalid arguments"));
+            return 1;
+        }
+
+        try
+        {
+            var json = File.ReadAllText(paramsPath);
+            _ = ParamsParser.Parse(action, json); // ensure parsing succeeds
+            WriteResult(resultPath, new JobResult("OK", $"{action} parsed"));
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            WriteResult(resultPath, new JobResult("Fail", ex.Message));
+            return 1;
+        }
+    }
+
+    private static bool TryParseArgs(string[] args, out string action, out string paramsPath, out string resultPath, out string? error)
+    {
+        action = paramsPath = resultPath = string.Empty;
+        error = null;
+
+        var dict = args.Select(a => a.Split('=', 2))
+                       .Where(kv => kv.Length == 2)
+                       .ToDictionary(kv => kv[0], kv => kv[1], StringComparer.OrdinalIgnoreCase);
+
+        if (!dict.TryGetValue("action", out action))
+        {
+            error = "Missing required argument 'action'";
+            return false;
+        }
+        if (!AllowedActions.Contains(action))
+        {
+            error = $"Unknown action '{action}'";
+            return false;
+        }
+        if (!dict.TryGetValue("params", out paramsPath))
+        {
+            error = "Missing required argument 'params'";
+            return false;
+        }
+        if (!dict.TryGetValue("result", out resultPath))
+        {
+            error = "Missing required argument 'result'";
+            return false;
+        }
+        if (!File.Exists(paramsPath))
+        {
+            error = "params.json not found";
+            return false;
+        }
+        return true;
+    }
+
+    private static void WriteResult(string path, JobResult result)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+            var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            {
+                WriteIndented = true
+            };
+            var json = JsonSerializer.Serialize(result, options);
+            File.WriteAllText(path, json);
+        }
+        catch
+        {
+            // suppress exceptions when writing result
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Sovcombank-demo
+
+Sample console application demonstrating argument parsing and JSON handling for Excel job operations.
+
+## Usage
+
+```
+dotnet run --project ExcelJobRunner -- action=updateLinks params=examples/params.json result=result.json
+```
+
+See `examples` directory for sample `params.json` and result files.

--- a/SovcombankDemo.sln
+++ b/SovcombankDemo.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExcelJobRunner", "ExcelJobRunner\ExcelJobRunner.csproj", "{0E312AA9-D504-46D4-B442-550C9E0A1BE9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExcelJobRunner.Tests", "ExcelJobRunner.Tests\ExcelJobRunner.Tests.csproj", "{AA8EA859-1BDE-42DA-AA4C-07EB26578951}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0E312AA9-D504-46D4-B442-550C9E0A1BE9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E312AA9-D504-46D4-B442-550C9E0A1BE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E312AA9-D504-46D4-B442-550C9E0A1BE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E312AA9-D504-46D4-B442-550C9E0A1BE9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA8EA859-1BDE-42DA-AA4C-07EB26578951}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA8EA859-1BDE-42DA-AA4C-07EB26578951}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA8EA859-1BDE-42DA-AA4C-07EB26578951}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA8EA859-1BDE-42DA-AA4C-07EB26578951}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/examples/params.json
+++ b/examples/params.json
@@ -1,0 +1,5 @@
+{
+  "inputFile": "C:\\files\\example.xlsx",
+  "cells": [{ "address": "Sheet1!A1", "newValue": "test" }],
+  "outputFile": "C:\\files\\updated.xlsx"
+}

--- a/examples/result.error.json
+++ b/examples/result.error.json
@@ -1,0 +1,4 @@
+{
+  "status": "Fail",
+  "message": "params.json not found"
+}

--- a/examples/result.ok.json
+++ b/examples/result.ok.json
@@ -1,0 +1,4 @@
+{
+  "status": "OK",
+  "message": "updateLinks parsed"
+}


### PR DESCRIPTION
## Summary
- create .NET console app to parse `action`, `params`, and `result` arguments
- add JSON models and parser for updateLinks, copyColumns, recalculate and findErrors actions
- include examples and unit test verifying params parsing

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6897b3fc9494832e8f93f88386a78c54