### PR TITLE
feat: implement updateLinks operation

### DIFF
--- a/ExcelJobRunner/ExcelJobRunner.csproj
+++ b/ExcelJobRunner/ExcelJobRunner.csproj
@@ -5,6 +5,11 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Office.Interop.Excel" Version="15.0.4795.1001" />
+  </ItemGroup>
 
 </Project>

--- a/ExcelJobRunner/UpdateLinksJob.cs
+++ b/ExcelJobRunner/UpdateLinksJob.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using ExcelJobRunner.Models;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace ExcelJobRunner;
+
+public static class UpdateLinksJob
+{
+    public static UpdateLinksResult Run(UpdateLinksParams p)
+    {
+        if (p.InputFile == null || p.OutputFile == null || p.Cells == null)
+        {
+            throw new ArgumentException("Invalid parameters");
+        }
+        if (!File.Exists(p.InputFile))
+        {
+            throw new FileNotFoundException("Input file not found", p.InputFile);
+        }
+
+        Excel.Application? app = null;
+        Excel.Workbook? wb = null;
+        var updated = new List<UpdatedCellResult>();
+        try
+        {
+            app = new Excel.Application { DisplayAlerts = false, Visible = false };
+            wb = app.Workbooks.Open(p.InputFile);
+
+            var operations = new List<(Excel.Range range, string newValue, string address, string oldValue)>();
+
+            foreach (var cell in p.Cells)
+            {
+                if (string.IsNullOrWhiteSpace(cell.Address))
+                {
+                    throw new Exception("Cell address is empty");
+                }
+                var split = cell.Address.Split('!');
+                if (split.Length != 2)
+                {
+                    throw new Exception($"Invalid cell address: {cell.Address}");
+                }
+                var sheetName = split[0];
+                var cellRef = split[1];
+
+                Excel.Worksheet? ws;
+                try
+                {
+                    ws = (Excel.Worksheet)wb.Worksheets[sheetName];
+                }
+                catch
+                {
+                    throw new Exception($"Sheet not found: {sheetName}");
+                }
+
+                Excel.Range range;
+                try
+                {
+                    range = ws.Range[cellRef];
+                }
+                catch
+                {
+                    throw new Exception($"Invalid cell address: {cell.Address}");
+                }
+
+                var oldVal = Convert.ToString(range.Value2) ?? string.Empty;
+                operations.Add((range, cell.NewValue ?? string.Empty, cell.Address, oldVal));
+            }
+
+            foreach (var op in operations)
+            {
+                op.range.Value2 = op.newValue;
+                updated.Add(new UpdatedCellResult(op.address, op.oldValue, op.newValue));
+            }
+
+            var dir = Path.GetDirectoryName(p.OutputFile);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            wb.SaveCopyAs(p.OutputFile);
+            return new UpdateLinksResult("OK", updated);
+        }
+        finally
+        {
+            if (wb != null)
+            {
+                wb.Close(false);
+                Marshal.ReleaseComObject(wb);
+            }
+            if (app != null)
+            {
+                app.Quit();
+                Marshal.ReleaseComObject(app);
+            }
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+    }
+}
+
+public record UpdateLinksResult(string Status, List<UpdatedCellResult> UpdatedCells);
+
+public record UpdatedCellResult(string Address, string OldValue, string NewValue);

--- a/examples/result.ok.json
+++ b/examples/result.ok.json
@@ -1,4 +1,10 @@
 {
   "status": "OK",
-  "message": "updateLinks parsed"
+  "updatedCells": [
+    {
+      "address": "Sheet1!A1",
+      "oldValue": "old",
+      "newValue": "test"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add Excel interop implementation for `updateLinks`
- hook up action invocation and structured result output
- include Excel interop package and windows targeting, update example result

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68997b02d5e4832eba16e6fe6bc37106