### PR TITLE
Implement recalculate operation

### DIFF
--- a/ExcelJobRunner.Tests/ParamsParserTests.cs
+++ b/ExcelJobRunner.Tests/ParamsParserTests.cs
@@ -59,4 +59,24 @@ public class ParamsParserTests
         Assert.Equal("Sheet1", parsed.Mappings![0].Source!.Sheet);
         Assert.Equal("M", parsed.Mappings![0].FillFormulaColumns![1]);
     }
+
+    [Fact]
+    public void RecalculateParams_CanBeReadFromJson()
+    {
+        var json = """
+{
+  "inputFile": "file.xlsb",
+  "outputFile": "out.xlsb",
+  "sheets": ["Sheet1", "Sheet2"]
+}
+""";
+
+        var result = ParamsParser.Parse("recalculate", json);
+
+        var parsed = Assert.IsType<RecalculateParams>(result);
+        Assert.Equal("file.xlsb", parsed.InputFile);
+        Assert.Equal("out.xlsb", parsed.OutputFile);
+        Assert.Equal(2, parsed.Sheets!.Count);
+        Assert.Equal("Sheet2", parsed.Sheets![1]);
+    }
 }

--- a/ExcelJobRunner/Program.cs
+++ b/ExcelJobRunner/Program.cs
@@ -32,6 +32,9 @@ public class Program
                 case "copyColumns":
                     result = CopyColumnsJob.Run((CopyColumnsParams)ParamsParser.Parse(action, json));
                     break;
+                case "recalculate":
+                    result = RecalculateJob.Run((RecalculateParams)ParamsParser.Parse(action, json));
+                    break;
                 default:
                     _ = ParamsParser.Parse(action, json);
                     result = new JobResult("OK", $"{action} parsed");

--- a/ExcelJobRunner/RecalculateJob.cs
+++ b/ExcelJobRunner/RecalculateJob.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using ExcelJobRunner.Models;
+using Excel = Microsoft.Office.Interop.Excel;
+using System.Reflection;
+
+namespace ExcelJobRunner;
+
+public static class RecalculateJob
+{
+    public static JobResult Run(RecalculateParams p)
+    {
+        if (p.InputFile == null || p.OutputFile == null)
+        {
+            throw new ArgumentException("Invalid parameters");
+        }
+        if (!File.Exists(p.InputFile))
+        {
+            throw new FileNotFoundException("Input file not found", p.InputFile);
+        }
+
+        Excel.Application? app = null;
+        Excel.Workbook? wb = null;
+        try
+        {
+            app = new Excel.Application { DisplayAlerts = false, Visible = false };
+            app.GetType().InvokeMember("AutomationSecurity", BindingFlags.SetProperty, null, app, new object[] { 3 });
+            wb = app.Workbooks.Open(p.InputFile);
+
+            wb.ForceFullCalculation = true;
+            app.CalculateFullRebuild();
+
+            var dir = Path.GetDirectoryName(p.OutputFile);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            if (string.Equals(p.InputFile, p.OutputFile, StringComparison.OrdinalIgnoreCase))
+            {
+                wb.Save();
+            }
+            else
+            {
+                wb.SaveCopyAs(p.OutputFile);
+            }
+
+            var message = $"Recalculation completed. File saved as {Path.GetFileName(p.OutputFile)}";
+            return new JobResult("OK", message);
+        }
+        finally
+        {
+            if (wb != null)
+            {
+                wb.Close(false);
+                Marshal.ReleaseComObject(wb);
+            }
+            if (app != null)
+            {
+                app.Quit();
+                Marshal.ReleaseComObject(app);
+            }
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `RecalculateJob` to force full workbook calculation and save output without macros
- integrate `recalculate` action into the CLI dispatcher
- cover `recalculate` parameter parsing with unit test

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689991e3e938832e8d70f49448633e68