### PR TITLE
Add runMacro operation for executing Excel macros

### DIFF
--- a/ExcelJobRunner.Tests/ParamsParserTests.cs
+++ b/ExcelJobRunner.Tests/ParamsParserTests.cs
@@ -79,4 +79,23 @@ public class ParamsParserTests
         Assert.Equal(2, parsed.Sheets!.Count);
         Assert.Equal("Sheet2", parsed.Sheets![1]);
     }
+
+    [Fact]
+    public void RunMacroParams_CanBeReadFromJson()
+    {
+        var json = """
+{
+  "inputFile": "C:\\files\\macrosource.xlsm",
+  "macroName": "Module1.MySpecialMacro",
+  "outputFile": "C:\\files\\macrosource_after_macro.xlsm"
+}
+""";
+
+        var result = ParamsParser.Parse("runMacro", json);
+
+        var parsed = Assert.IsType<RunMacroParams>(result);
+        Assert.Equal("C:\\files\\macrosource.xlsm", parsed.InputFile);
+        Assert.Equal("Module1.MySpecialMacro", parsed.MacroName);
+        Assert.Equal("C:\\files\\macrosource_after_macro.xlsm", parsed.OutputFile);
+    }
 }

--- a/ExcelJobRunner/Models/RunMacroParams.cs
+++ b/ExcelJobRunner/Models/RunMacroParams.cs
@@ -1,0 +1,8 @@
+namespace ExcelJobRunner.Models;
+
+public class RunMacroParams
+{
+    public string? InputFile { get; set; }
+    public string? MacroName { get; set; }
+    public string? OutputFile { get; set; }
+}

--- a/ExcelJobRunner/ParamsParser.cs
+++ b/ExcelJobRunner/ParamsParser.cs
@@ -21,6 +21,8 @@ public static class ParamsParser
                                ?? throw new JsonException("Invalid copyColumns params"),
             "recalculate" => JsonSerializer.Deserialize<RecalculateParams>(json, Options)
                                ?? throw new JsonException("Invalid recalculate params"),
+            "runMacro" => JsonSerializer.Deserialize<RunMacroParams>(json, Options)
+                               ?? throw new JsonException("Invalid runMacro params"),
             "findErrors" => JsonSerializer.Deserialize<FindErrorsParams>(json, Options)
                                ?? throw new JsonException("Invalid findErrors params"),
             _ => throw new ArgumentException($"Unknown action: {action}")

--- a/ExcelJobRunner/Program.cs
+++ b/ExcelJobRunner/Program.cs
@@ -10,7 +10,7 @@ namespace ExcelJobRunner;
 
 public class Program
 {
-    private static readonly HashSet<string> AllowedActions = new(new[] { "updateLinks", "copyColumns", "recalculate", "findErrors" });
+    private static readonly HashSet<string> AllowedActions = new(new[] { "updateLinks", "copyColumns", "recalculate", "findErrors", "runMacro" });
 
     public static int Main(string[] args)
     {
@@ -35,6 +35,9 @@ public class Program
                     break;
                 case "recalculate":
                     result = RecalculateJob.Run((RecalculateParams)ParamsParser.Parse(action, json));
+                    break;
+                case "runMacro":
+                    result = RunMacroJob.Run((RunMacroParams)ParamsParser.Parse(action, json));
                     break;
                 default:
                     _ = ParamsParser.Parse(action, json);

--- a/ExcelJobRunner/RunMacroJob.cs
+++ b/ExcelJobRunner/RunMacroJob.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Reflection;
+using ExcelJobRunner.Models;
+using Excel = Microsoft.Office.Interop.Excel;
+
+namespace ExcelJobRunner;
+
+public static class RunMacroJob
+{
+    public static JobResult Run(RunMacroParams p)
+    {
+        if (p.InputFile == null || p.MacroName == null || p.OutputFile == null)
+        {
+            throw new ArgumentException("Invalid parameters");
+        }
+        if (!File.Exists(p.InputFile))
+        {
+            throw new FileNotFoundException("Input file not found", p.InputFile);
+        }
+
+        Excel.Application? app = null;
+        Excel.Workbook? wb = null;
+        try
+        {
+            app = new Excel.Application { DisplayAlerts = false, Visible = false };
+            app.GetType().InvokeMember("AutomationSecurity", BindingFlags.SetProperty, null, app, new object[] { 1 });
+            wb = app.Workbooks.Open(p.InputFile);
+
+            try
+            {
+                app.Run(p.MacroName);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error executing macro '{p.MacroName}': {ex.Message}", ex);
+            }
+
+            var dir = Path.GetDirectoryName(p.OutputFile);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+            wb.SaveCopyAs(p.OutputFile);
+
+            var message = $"Macro '{p.MacroName}' executed and file saved as {Path.GetFileName(p.OutputFile)}";
+            return new JobResult("OK", message);
+        }
+        finally
+        {
+            if (wb != null)
+            {
+                wb.Close(false);
+                Marshal.ReleaseComObject(wb);
+            }
+            if (app != null)
+            {
+                app.Quit();
+                Marshal.ReleaseComObject(app);
+            }
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ ExcelJobRunner.exe action=updateLinks params=C:\tmp\params.json result=C:\tmp\re
 2. `findErrors` — поиск ошибок в заданных столбцах листа
 3. `copyColumns` — копирование столбцов (или ячеек) между файлами
 4. `recalculate` — принудительный пересчёт всех формул файла
+5. `runMacro` — запуск указанного макроса VBA и сохранение результата в отдельный файл
 
 ## Формат входных параметров (`params.json`)
 
@@ -77,6 +78,15 @@ ExcelJobRunner.exe action=updateLinks params=C:\tmp\params.json result=C:\tmp\re
 {
   "inputFile": "C:\\files\\calculations.xlsm",
   "outputFile": "C:\\files\\calculations_recalculated.xlsm"
+}
+```
+
+### 5. `runMacro`
+```json
+{
+  "inputFile": "C:\\files\\macrosource.xlsm",
+  "macroName": "Module1.MySpecialMacro",
+  "outputFile": "C:\\files\\macrosource_after_macro.xlsm"
 }
 ```
 


### PR DESCRIPTION
## Summary
- add RunMacroJob to execute a specified VBA macro and save output to a new file
- extend parameter parsing, allowed actions, and docs for new runMacro operation
- cover runMacro params in unit tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6899af5da730832eaea6dcb5689c3f5b